### PR TITLE
Publish JointState messages for the wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,12 @@ $ roslaunch ca_driver create_1.launch [publish_tf:=true]
  `dock_button` | 'dock' button is pressed ('advance' button for Create 1) | [std_msgs/Empty][empty]
  `spot_button` | 'spot' button is pressed | [std_msgs/Empty][empty]
  `ir_omni` | The IR character currently being read by the omnidirectional receiver. Value 0 means no character is being received | [std_msgs/UInt16][uint16]
+ `joint_states` | The states (position, velocity) of the drive wheel joints | [sensor_msgs/JointState][jointstate_msg]
  `mode` | The current mode of the robot (See [OI Spec][oi_spec] for details)| [ca_msgs/Mode][mode_msg]
  `odom` |  Robot odometry according to wheel encoders | [nav_msgs/Odometry][odometry]
  `wheeldrop` | At least one of the drive wheels has dropped | [std_msgs/Empty][empty]
  `/tf` | The transform from the `odom` frame to `base_footprint`. Only if the parameter `publish_tf` is `true` | [tf2_msgs/TFMessage](http://docs.ros.org/jade/api/tf2_msgs/html/msg/TFMessage.html)
+
 
 ### Subscribers
 
@@ -226,3 +228,4 @@ Contributing to the development and maintenance of _create\_autonomy_ is encoura
 [bumper_msg]:  https://github.com/AutonomyLab/create_autonomy/blob/indigo-devel/ca_msgs/msg/Bumper.msg
 [mode_msg]:  https://github.com/AutonomyLab/create_autonomy/blob/indigo-devel/ca_msgs/msg/Mode.msg
 [chargingstate_msg]:  https://github.com/AutonomyLab/create_autonomy/blob/indigo-devel/ca_msgs/msg/ChargingState.msg
+[jointstate_msg]:  http://docs.ros.org/api/sensor_msgs/html/msg/JointState.html

--- a/ca_driver/CMakeLists.txt
+++ b/ca_driver/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   geometry_msgs
   nav_msgs
+  sensor_msgs
   tf
   ca_msgs
 )
@@ -15,13 +16,13 @@ find_package(Boost REQUIRED system thread)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES libcreate
-  CATKIN_DEPENDS roscpp std_msgs geometry_msgs nav_msgs tf ca_msgs ca_description
+  CATKIN_DEPENDS roscpp std_msgs geometry_msgs nav_msgs sensor_msgs tf ca_msgs ca_description
 )
 
 include(ExternalProject)
 ExternalProject_Add(libcreate
   GIT_REPOSITORY https://github.com/AutonomyLab/libcreate.git
-  GIT_TAG 1.2.1
+  GIT_TAG master
   PREFIX ${CATKIN_DEVEL_PREFIX}
   CONFIGURE_COMMAND cmake .
   BUILD_COMMAND make

--- a/ca_driver/include/create_driver/create_driver.h
+++ b/ca_driver/include/create_driver/create_driver.h
@@ -8,6 +8,7 @@
 #include <std_msgs/UInt16.h>
 #include <std_msgs/Int16.h>
 #include <std_msgs/UInt8MultiArray.h>
+#include <sensor_msgs/JointState.h>
 #include <geometry_msgs/Twist.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <nav_msgs/Odometry.h>
@@ -42,6 +43,7 @@ private:
   std_msgs::Float32 float32_msg_;
   std_msgs::UInt16 uint16_msg_;
   std_msgs::Int16 int16_msg_;
+  sensor_msgs::JointState joint_state_msg_;
 
   // ROS params
   double loop_hz_;
@@ -62,6 +64,7 @@ private:
 
   bool update();
   void publishOdom();
+  void publishJointState();
   void publishBatteryInfo();
   void publishButtonPresses() const;
   void publishOmniChar();
@@ -100,6 +103,7 @@ protected:
   ros::Publisher mode_pub_;
   ros::Publisher bumper_pub_;
   ros::Publisher wheeldrop_pub_;
+  ros::Publisher wheel_joint_pub_;
 
 public:
   CreateDriver(ros::NodeHandle& nh);

--- a/ca_driver/package.xml
+++ b/ca_driver/package.xml
@@ -18,6 +18,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>ca_msgs</build_depend>
 
@@ -25,6 +26,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>ca_msgs</run_depend>
   <run_depend>ca_description</run_depend>


### PR DESCRIPTION
This PR adds support for publishing JointState messages for the wheels on the Create. This allows robot_state_publisher to generate transforms for the wheels. These messages could also allow other nodes to access the velocities of the wheels.

This fixes #25.

To support these changes, AutonomyLab/libcreate#19 must be merged.
