### PR TITLE
Update create_autonomy to support the Roomba 400

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ TravisCI (Ubuntu _Trusty_, ROS _Indigo_ and _Jade_)
 | Create 1  |  Yes       |
 | Create 2  _(firmware >= 3.2.6)_ |  Yes       |
 | Roomba Original Series | No  |
-| Roomba 400 Series |  No  |
+| Roomba 400 Series |  Yes  |
 | Roomba 500 Series |  Yes *  |
 | Roomba 600 Series |  Yes * |
 | Roomba 700 Series |  Yes +  |
@@ -138,7 +138,7 @@ $ roslaunch ca_driver create_1.launch [publish_tf:=true]
 `loop_hz`   |  Frequency of internal update loop |  `10.0`
 `dev`       |  Serial port |  `/dev/ttyUSB0`
 `publish_tf`|  Publish the transform between `odom` and `base_footprint` frames | `true`  
-`create_1`  |  Is robot model Create 1 (Roomba 400 series)?  | `false`
+`robot_model` |  The name of the robot being controlled (supported values: `ROOMBA_400`, `CREATE_1` and `CREATE_2`) | `CREATE_2`
 `latch_cmd_duration` | If this many seconds passes without receiving a velocity command the robot stops | `0.2`
 
 

--- a/ca_description/launch/roomba_400.launch
+++ b/ca_description/launch/roomba_400.launch
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find ca_description)/urdf/create_1.urdf.xacro'" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen"/>
+</launch>


### PR DESCRIPTION
This adds a new `robot_model` parameter that specifies the name of the robot to use. The currently supported values are:
- `ROOMBA_400`
- `CREATE_1`
- `CREATE_2`

The `create_1` boolean parameter is still supported and overrides `robot_model` if present.
