### PR TITLE
removed 'TO DO'

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [ROS](http://ros.org) driver for iRobot [Create 1 and 2](http://www.irobot.com/About-iRobot/STEM/Create-2.aspx).
 This package wraps the C++ library [libcreate][libcreate], which uses iRobot's [Open Interface Specification][oi_spec].
 
-[](* Documentation: TODO)
+<!--[](* Documentation: TODO)-->
 * ROS wiki page: http://wiki.ros.org/create_autonomy
 * Support: [ROS Answers (tag: create_autonomy)](http://answers.ros.org/questions/scope:all/sort:activity-desc/tags:create_autonomy/page:1/)
 * Author: [Jacob Perron](http://jacobperron.ca) ([Autonomy Lab](http://autonomylab.org), [Simon Fraser University](http://www.sfu.ca))


### PR DESCRIPTION
changed '' [](* Documentation: TODO)'' to an invisible comment. 
Any other future to-do list items can be hidden (if included within the HTML comment).