### PR TITLE
Fixed left/right wheel joints in gazebo diff drive plugin parameters

### DIFF
--- a/create_description/urdf/create_base_gazebo.urdf.xacro
+++ b/create_description/urdf/create_base_gazebo.urdf.xacro
@@ -5,8 +5,8 @@
       <plugin name="differential_drive_controller" filename="libgazebo_ros_diff_drive.so">
         <alwaysOn>true</alwaysOn>
         <updateRate>${diffdrive_update_rate}</updateRate>
-        <leftJoint>right_wheel_joint</leftJoint>
-        <rightJoint>left_wheel_joint</rightJoint>
+        <leftJoint>left_wheel_joint</leftJoint>
+        <rightJoint>right_wheel_joint</rightJoint>
         <wheelSeparation>${wheel_separation}</wheelSeparation>
         <wheelDiameter>${wheel_radius * 2}</wheelDiameter>
         <wheelTorque>${wheel_torque}</wheelTorque>


### PR DESCRIPTION
Hello,

I've been working on setting up navigation in simulation for the Create 2 recently and noticed that I could not get move_base to steer the robot towards the goal.

I noticed that the left and right wheel joint parameters were reversed in the gazebo urdf file.

When I switched them move_base could navigate successfully.