### PR TITLE
Yaml create driver node name

### DIFF
--- a/create_bringup/config/default.yaml
+++ b/create_bringup/config/default.yaml
@@ -7,7 +7,7 @@ create_driver:
     # baud: 115200
 
     # Base frame ID
-    base_frame: "base_link"
+    base_frame: "base_footprint"
 
     # Odometry frame ID
     odom_frame: "odom"

--- a/create_bringup/config/default.yaml
+++ b/create_bringup/config/default.yaml
@@ -1,4 +1,4 @@
-create_node:
+create_driver:
   ros__parameters:
     # The device path for the robot
     dev: "/dev/ttyUSB0"
@@ -7,7 +7,7 @@ create_node:
     # baud: 115200
 
     # Base frame ID
-    base_frame: "base_footprint"
+    base_frame: "base_link"
 
     # Odometry frame ID
     odom_frame: "odom"

--- a/create_bringup/launch/create_2.launch
+++ b/create_bringup/launch/create_2.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="config" default="$(find-pkg-share create_bringup)/config/default.yaml" />
-  <arg name="desc" default="true" />
+  <arg name="desc" default="false" />
 
   <node name="create_driver" pkg="create_driver" exec="create_driver" output="screen">
     <param from="$(var config)" />

--- a/create_bringup/launch/create_2.launch
+++ b/create_bringup/launch/create_2.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="config" default="$(find-pkg-share create_bringup)/config/default.yaml" />
-  <arg name="desc" default="false" />
+  <arg name="desc" default="true" />
 
   <node name="create_driver" pkg="create_driver" exec="create_driver" output="screen">
     <param from="$(var config)" />


### PR DESCRIPTION
Thank you for porting this to ros2 foxy. When I tried to modify parameters (e.g. base_frame) in the original default.yaml, nothing changed. I realized it is because the first line in the yaml needs to be the node name, create_driver, which is defined in the launch file.