### PR TITLE
Disable libcreate's signal handler

### DIFF
--- a/create_driver/src/create_driver.cpp
+++ b/create_driver/src/create_driver.cpp
@@ -72,7 +72,8 @@ CreateDriver::CreateDriver()
 
   baud_ = declare_parameter<int>("baud", model_.getBaud());
 
-  robot_ = new create::Create(model_);
+  // Disable signal handler; let rclcpp handle them
+  robot_ = new create::Create(model_, false);
 
   if (!robot_->connect(dev_, baud_))
   {


### PR DESCRIPTION
Fixes #87

Since rclcpp is already handling signals, we don't need libcreate interfering.
We are already making sure to properly disconnect from the robot before the process ends.

Depends on https://github.com/AutonomyLab/libcreate/pull/65